### PR TITLE
Use Github Actions as a CI for Linux x86_64 and aarch64

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Build
+      run:  make
+
+  build-aarch64:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Build
+      uses: uraimo/run-on-arch-action@v2
+      with:
+        arch: aarch64
+        distro: ubuntu20.04
+        githubToken: ${{ github.token }}
+        dockerRunArgs: |
+          --volume "${PWD}:/MCScanX"
+        install: |
+          apt-get update -q -y
+          apt-get install -q -y make gcc g++ default-jdk
+        run: |
+          cd /MCScanX
+          echo "Building..."
+          make


### PR DESCRIPTION
Related-to: https://github.com/wyp1125/MCScanX/issues/55

CI results could be seen on my fork: [![CI](https://github.com/martin-g/MCScanX/actions/workflows/ci.yaml/badge.svg)](https://github.com/martin-g/MCScanX/actions/workflows/ci.yaml)